### PR TITLE
Changing phpunit from 6.0.0 to 5.7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "nesbot/carbon": "^1.22"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.2",
+        "phpunit/phpunit": "~5.7.0",
         "orchestra/testbench": "^3.4"
     },
     "autoload": {


### PR DESCRIPTION
When using the composer argument: --prefer-lowest, an error occurred.
We fixed this by dowgrading phpunit from 6.0.0 to 5.7.0

More information at:
* https://github.com/orchestral/testbench/releases/tag/v3.4.2